### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,5 @@
-var Mongo = require("github.com/quilt/mongo");
+const {createDeployment, Machine, Range, githubKeys} = require("@quilt/quilt");
+var Mongo = require("./mongo.js");
 var nWorker = 3;
 
 var deployment = createDeployment({});

--- a/mongo.js
+++ b/mongo.js
@@ -1,3 +1,4 @@
+const {Container, Service} = require("@quilt/quilt");
 var image = "quilt/mongo";
 
 function Mongo(nWorker) {

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./mongo.js"
+  "name": "@quilt/mongo",
+  "version": "0.0.1",
+  "main": "./mongo.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.