### PR TITLE
Dockerfile: Install ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mongo:3.2
 COPY start.go /
 
 RUN apt-get -y update \
-&& apt-get install -y golang-go \
+&& apt-get install -y golang-go iputils-ping\
 && go build /start.go \
 && apt-get remove --purge -y golang-go \
 && apt-get -y autoremove \


### PR DESCRIPTION
A recent update to the underlying Mongo container
(which we inherit from) removed ping.  We need it:
start.go uses ping to check that the other mongo
instances are up.